### PR TITLE
add support for runtime and layers

### DIFF
--- a/src/_json.js
+++ b/src/_json.js
@@ -23,7 +23,9 @@ function _json(raw) {
     if (section === 'aws') {
       result.aws = [
         ['region', json[section].region],
-        ['profile', json[section].profile]
+        ['profile', json[section].profile],
+        ['runtime', json[section].runtime],
+        ['layers', json[section].layers]
       ]
     }
 
@@ -114,6 +116,15 @@ _json.stringify = function _stringify(json) {
     result += `@aws\n`
     result += `region ${raw.aws.region}\n`
     result += `profile ${raw.aws.profile}\n`
+    if (raw.aws.runtime) {
+      result += `runtime ${raw.aws.runtime}\n`
+    }
+
+    if (raw.aws.layers) {
+      raw.aws.layers.forEach(layer=> {
+        result += `layer ${layer}\n`
+      })
+    }
     result += '\n'
   }
   if (raw.static) {

--- a/test/05-mock-arc.json
+++ b/test/05-mock-arc.json
@@ -4,7 +4,12 @@
   "domain": "testapp.com",
   "aws": {
     "region": "us-west-2",
-    "profile": "personal"
+    "profile": "personal",
+    "runtime": "nodejs8.10",
+    "layers": [
+      "arn:aws:lambda:us-west-2:111111111111:layer:test:2",
+      "arn:aws:lambda:us-west-2:111111111111:layer:test:1"
+    ]
   },
   "static": {
     "staging": "testapp-bucket",

--- a/test/06-mock-arc.yaml
+++ b/test/06-mock-arc.yaml
@@ -5,6 +5,10 @@ domain: testapp.com
 aws:
   region: us-west-2
   profile: personal
+  runtime: nodejs8.10
+  layers:
+    - arn:aws:lambda:us-west-2:111111111111:layer:test:2
+    - arn:aws:lambda:us-west-2:111111111111:layer:test:1
 static:
   staging: testapp-bucket
   production: testapp-buckea-prod


### PR DESCRIPTION
This adds support to `runtime` and `layers` on the JSON and Yaml files

Layers, in this case, is special, for JSON and Yaml it will be set as an array

```
runtime: 'nodejs8.10'
layers:
 - arn:aws:xxx:1
 - arn:aws:xxxx:2
```

But in the arc file it will be translated as a list of tuples

```
@aws
layer arn:aws:xxx:1
layer arn:aws:xxx:2
```